### PR TITLE
Add depend on opengl

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,10 +10,12 @@
   <buildtool_depend>cmake</buildtool_depend>
   <build_depend>boost</build_depend>
   <build_depend>libopenscenegraph</build_depend>
+  <build_depend>opengl</build_depend>
   
   <run_depend>catkin</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>libopenscenegraph</run_depend>
+  <run_depend>opengl</run_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
OpenGL is `find_package()`'d in the `CMakeLists.txt` and should be listed as a dependency.

`opengl` is in rosdep: https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L2115-L2124
